### PR TITLE
Set tag to Windows Docker image

### DIFF
--- a/windows/aspnetcore/docker-compose.yml
+++ b/windows/aspnetcore/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - virto
 
   vc-storefront-web:
-    image: virtocommerce/storefront:${DOCKER_TAG:-latest}
+    image: virtocommerce/storefront:${DOCKER_TAG:-dev-branch}
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
     environment:


### PR DESCRIPTION
The storefront latest points to a Linux image use the `dev-branch` Windows version instead